### PR TITLE
fix(luxcavation): issue 270 将Lv60识别为LvG0的bug

### DIFF
--- a/lalc_backend/task_action/luxcavation.py
+++ b/lalc_backend/task_action/luxcavation.py
@@ -48,11 +48,11 @@ def exec_thread_select_stage(self, node: TaskNode, func):
     time.sleep(1)
 
     target_stage = cfg["thread_stage"]
-    pos = recognize_handler.find_text_in_image(input_handler.capture_screenshot(), target_stage, mask=[570, 170, 90, 400])
+    pos = recognize_handler.find_text_in_image(input_handler.capture_screenshot(), target_stage, mask=[610, 170, 90, 400])
     while len(pos) == 0:
         input_handler.swipe(650, 325, 650, 430)
         time.sleep(0.6)
-        pos = recognize_handler.find_text_in_image(input_handler.capture_screenshot(), target_stage, mask=[570, 170, 90, 400])
+        pos = recognize_handler.find_text_in_image(input_handler.capture_screenshot(), target_stage, mask=[610, 170, 90, 400])
 
     input_handler.click(pos[0][1], pos[0][2])
 


### PR DESCRIPTION
#270 测试中发现识别结果与图像遮罩区域有关，不遮罩或缩小遮罩区域的玄学方法都可以修复这个玄学错误。通过缩小遮罩区域进行了修复